### PR TITLE
v2.0.0: Un-silence exception in send_message.

### DIFF
--- a/xymon/__init__.py
+++ b/xymon/__init__.py
@@ -73,8 +73,8 @@ class Xymon(object):
 
         See the xymon(1) man page for message syntax.
         """
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             server_ip = socket.gethostbyname(self.server)
             message = message + '\n'
             s.connect((server_ip, self.port))

--- a/xymon/__init__.py
+++ b/xymon/__init__.py
@@ -15,7 +15,7 @@ else:
     from urllib.parse import urlencode
 
 
-__version__ = '1.2.0'
+__version__ = '2.0.0'
 
 
 class Xymon(object):
@@ -75,22 +75,13 @@ class Xymon(object):
         """
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        except socket.error:
-            # socket creation failed
-            return False
-        try:
             server_ip = socket.gethostbyname(self.server)
-        except socket.gaierror:
-            # DNS lookup error
-            return False
-        try:
             message = message + '\n'
             s.connect((server_ip, self.port))
             s.sendall(message.encode())
-            return True
-        except socket.error:
-            # connection refused
-            return False
+        except:
+            # Re-raising the exceptions as this should not pass silently.
+            raise
         finally:
             s.close()
 


### PR DESCRIPTION
Un-silence exceptions on send_message by re-raising.
This way the caller does not have to check the return value to see if the call was successful: that is what exceptions are for.
And in case of error it sees what kind of error occurred in stead of of a simple 'failed'.
As it breaks API I've bumped the version to 2.0.0.